### PR TITLE
Parsing undocumented fields in PropertyListings and changing a few types

### DIFF
--- a/src/Zoopla.Net/Models/ArrangeViewing/ArrangeViewingResponse.cs
+++ b/src/Zoopla.Net/Models/ArrangeViewing/ArrangeViewingResponse.cs
@@ -15,6 +15,8 @@ namespace Zoopla.Net.Models
         /// </value>
         public int Success { get; set; }
 
+        public bool IsSuccess => Success == 1;
+
         public string Error { get; set; }
     }
 }

--- a/src/Zoopla.Net/Models/Listings/ImageAndDescription.cs
+++ b/src/Zoopla.Net/Models/Listings/ImageAndDescription.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Zoopla.Net.Models.Listings
+{
+    public class ImageAndDescription
+    {
+        [JsonProperty("url")]
+        public string Url { get; set; }
+        [JsonProperty("description")]
+        public string Description { get; set; }
+    }
+}

--- a/src/Zoopla.Net/Models/Listings/Listing.cs
+++ b/src/Zoopla.Net/Models/Listings/Listing.cs
@@ -1,22 +1,43 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Zoopla.Net.Models.Listings
 {
     public class Listing
     {
+        /// <summary>
+        /// e.g. gb (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("country_code")]
+        public string CountryCode { get; set; }
         [JsonProperty("num_floors")]
-        public string NumberOfFloors { get; set; }
+        public int NumberOfFloors { get; set; }
+        /// <summary>
+        /// 150px X 113px image. (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("image_150_113_url")]
+        public string ImageSmall { get; set; }
+        /// <summary>
+        /// The current listings status of this property, either "sale" or "rent".
+        /// </summary>
         [JsonProperty("listing_status")]
         public string ListingStatus { get; set; }
         [JsonProperty("num_bedrooms")]
-        public string NumberOfBedrooms { get; set; }
+        public int NumberOfBedrooms { get; set; }
+        /// <summary>
+        /// 50px X 38px image. (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("image_50_38_url")]
+        public string ImageTiny { get; set; }
         public double Latitude { get; set; }
         [JsonProperty("agent_address")]
         public string AgentAddress { get; set; }
+        /// <summary>
+        /// e.g. Residential (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("category")]
+        public string Category { get; set; }
         [JsonProperty("property_type")]
         public string PropertyType { get; set; }
         public double Longitude { get; set; }
@@ -30,45 +51,95 @@ namespace Zoopla.Net.Models.Listings
         [JsonProperty("short_description")]
         public string ShortDescription { get; set; }
         public string Outcode { get; set; }
+        /// <summary>
+        /// Undocumented - use with caution
+        /// </summary>
+        [JsonProperty("property_report_url")]
+        public string PropertyReportUrl { get; set; }
+        /// <summary>
+        /// List of all images for carousel in 354px X 255px (same as ImageLarge size). (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("other_image")]
+        public IEnumerable<ImageAndDescription> OtherImages { get; set; }
+        /// <summary>
+        /// 645px X 430px image. (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("image_645_430_url")]
+        public string ImageExtraLarge { get; set; }
         public string County { get; set; }
-        public string Price { get; set; }
+        public int Price { get; set; }
         [JsonProperty("listing_id")]
-        public string ListingId { get; set; }
+        public int ListingId { get; set; }
         [JsonProperty("image_caption")]
         public string ImageCaption { get; set; }
+        /// <summary>
+        /// List of key bullet point features. (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("bullet")]
+        public IEnumerable<string> BulletPoints { get; set; }
+        /// <summary>
+        /// 80px X 60px image. (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("image_80_60_url")]
+        public string ImageThumbnail { get; set; }
+        /// <summary>
+        /// e.g. 5 Oldman Court (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("property_number")]
+        public string PropertyName { get; set; }
         public string Status { get; set; }
         [JsonProperty("agent_name")]
         public string AgentName { get; set; }
         [JsonProperty("num_recepts")]
-        public string NumberOfReceptions { get; set; }
+        public int NumberOfReceptions { get; set; }
         public string Country { get; set; }
         [JsonProperty("displayable_address")]
         public string DisplayableAddress { get; set; }
         [JsonProperty("first_published_date")]
-        public string FirstPublishedDate { get; set; }
+        public DateTime FirstPublishedDate { get; set; }
         [JsonProperty("floor_plan")]
-        public List<string> FloorPlan { get; set; }
+        public IEnumerable<string> FloorPlan { get; set; }
         [JsonProperty("street_name")]
         public string StreetName { get; set; }
         [JsonProperty("num_bathrooms")]
-        public string NumberOfBathrooms { get; set; }
+        public int NumberOfBathrooms { get; set; }
+        /// <summary>
+        /// Undocumented - use with caution
+        /// </summary>
+        public string Incode { get; set; }
         [JsonProperty("price_change")]
-        public List<PriceChange> PriceChange { get; set; }
+        public IEnumerable<PriceChange> PriceChange { get; set; }
         [JsonProperty("agent_logo")]
         public string AgentLogo { get; set; }
         [JsonProperty("agent_phone")]
         public string AgentPhone { get; set; }
+        /// <summary>
+        /// 354px X 255px image. (Undocumented - use with caution)
+        /// </summary>
+        [JsonProperty("image_354_255_url")]
+        public string ImageLarge { get; set; }
         [JsonProperty("image_url")]
         public string ImageUrl { get; set; }
         [JsonProperty("last_published_date")]
-        public string LastPublishedDate { get; set; }
+        public DateTime LastPublishedDate { get; set; }
         [JsonProperty("price_change_summary")]
         public PriceChangeSummary PriceChangeSummary { get; set; }
         [JsonProperty("price_modifier")]
         public string PriceModifier { get; set; }
+        /// <summary>
+        /// Undocumented - use with caution
+        /// </summary>
         [JsonProperty("new_home")]
         public string NewHome { get; set; }
+        /// <summary>
+        /// Undocumented - use with caution
+        /// </summary>
         [JsonProperty("letting_fees")]
         public string LettingFees { get; set; }
+        /// <summary>
+        /// Undocumented - use with caution
+        /// </summary>
+        [JsonProperty("original_image")]
+        public IEnumerable<string> OriginalImages { get; set; }
     }
 }

--- a/src/Zoopla.Net/Models/Listings/PriceChange.cs
+++ b/src/Zoopla.Net/Models/Listings/PriceChange.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Zoopla.Net.Models.Listings
 {
     public class PriceChange
     {
         public string Direction { get; set; }
-        public string Date { get; set; }
+        public DateTime Date { get; set; }
         public string Percent { get; set; }
-        public string Price { get; set; }
+        public int Price { get; set; }
     }
 }

--- a/src/Zoopla.Net/Models/Listings/PriceChangeSummary.cs
+++ b/src/Zoopla.Net/Models/Listings/PriceChangeSummary.cs
@@ -1,8 +1,5 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Zoopla.Net.Models.Listings
 {
@@ -11,6 +8,6 @@ namespace Zoopla.Net.Models.Listings
         public string Direction { get; set; }
         public string Percent { get; set; }
         [JsonProperty("last_updated_date")]
-        public string LastUpdatedDate { get; set; }
+        public DateTime LastUpdatedDate { get; set; }
     }
 }

--- a/src/Zoopla.Net/Options/ArrangeViewing/ArrangeViewingOptions.cs
+++ b/src/Zoopla.Net/Options/ArrangeViewing/ArrangeViewingOptions.cs
@@ -8,6 +8,10 @@ namespace Zoopla.Net.Options
 {
     public class ArrangeViewingOptions : OptionsBase
     {
+        /// <summary>
+        /// For testing purposes, we have blacklisted zoopla_developer@mashery.com for your convenience. 
+        /// </summary>
+        public const string TestEmail = "zoopla_developer@mashery.com";
 
         public string SessionId
         {
@@ -17,11 +21,11 @@ namespace Zoopla.Net.Options
             }
         }
 
-        public string ListingId
+        public int ListingId
         {
             set
             {
-                UrlValues["listing_id"] = value;
+                UrlValues["listing_id"] = value.ToString();
             }
         }
 


### PR DESCRIPTION
May seem dangerous changing some types from string to DateTime or int but I have been using the Zoopla API for years now (direct HTTP) and parsing these fields to these types successfully all along so quite confident it is safe.

Also seems like their documentation is out of date since there are a lot of useful fields they are returning in property_listings api such as an array of images for a carousel.

For what it is worth I am quite confident PropertyListings, ArrangeViewing and GetSession are feature complete now.