### PR TITLE
Add disambiguation property to base response

### DIFF
--- a/src/Zoopla.Net/Models/ResponseModelBase.cs
+++ b/src/Zoopla.Net/Models/ResponseModelBase.cs
@@ -29,5 +29,7 @@ namespace Zoopla.Net.Models
 
         [JsonProperty("error_code")]
         public string ErrorCode { get; set; }
+
+        public IEnumerable<string> Disambiguation { get; set; }
     }
 }


### PR DESCRIPTION
When searching by areas Zoopla can return an array of potential areas for the user to use to disambiguate between. Docs: https://developer.zoopla.co.uk/docs/read/Home

e.g. Searching property in St James's Park, London returns JSON like this:
`{
disambiguation: [
"St. James's Park, Croydon, CR0",
"St. James's Park, London, SW1A"
],
error_string: "Disambiguation required.",
error_code: -1
}`

This PR simply adds the Disambiguation property. Tested and works great and will be really useful