### PR TITLE
Get properties by ID without specifying sale or rent

### DIFF
--- a/src/Zoopla.Net/IZooplaDotNetClient.cs
+++ b/src/Zoopla.Net/IZooplaDotNetClient.cs
@@ -13,6 +13,7 @@ namespace Zoopla.Net
         Task<AverageSoldPriceResponse> GetAverageSoldPrices(StandardLocationParameters locationParams, AverageSoldPricesOptions options);
         Task<GeoAutocompleteResponse> GetGeoAutocomplete(GeoAutocompleteOptions options);
         Task<LocalInfoGraphResponse> GetLocalInfoGraphs(StandardLocationParameters locationParams);
+        Task<PropertyListingsResponse> GetPropertyListingsByIds(ListingBaseOptions options);
         Task<PropertyListingsResponse> GetPropertyListings(StandardLocationParameters locationParams, ListingBaseOptions options);
         Task<PropertyRichListResponse> GetPropertyRichList(StandardLocationParameters locationParams);
         Task<RefineEstimateResponse> GetRefineEstimate(RefineEstimateOptions options);

--- a/src/Zoopla.Net/Options/Listings/ByIdListingOptions.cs
+++ b/src/Zoopla.Net/Options/Listings/ByIdListingOptions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Zoopla.Net.Options
+{
+    public class ByIdListingOptions : ListingBaseOptions
+    {
+        /// <summary>
+        /// Options for searching for property by an ID or IDs
+        /// </summary>
+        /// <param name="id">An ID or a comma separated list of IDs</param>
+        public ByIdListingOptions(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+                throw new ArgumentNullException(nameof(id));
+
+            ListingId = id;
+            IncludeSoldAndRented = false;
+        }
+
+        /// <summary>
+        /// You can include sold and rented properties. By default these are excluded
+        /// </summary>
+        public bool IncludeSoldAndRented
+        {
+            set
+            {
+                UrlValues["include_sold"] = value ? "1" : "0";
+                UrlValues["include_rented"] = value ? "1" : "0";
+            }
+        }
+    }
+}

--- a/src/Zoopla.Net/Options/Listings/ListingBaseOptions.cs
+++ b/src/Zoopla.Net/Options/Listings/ListingBaseOptions.cs
@@ -80,6 +80,10 @@ namespace Zoopla.Net.Options
         }
         public string ListingId
         {
+            internal get
+            {
+                return UrlValues["listing_id"];
+            }
             set
             {
                 UrlValues["listing_id"] = value;

--- a/src/Zoopla.Net/Zoopla.Net.csproj
+++ b/src/Zoopla.Net/Zoopla.Net.csproj
@@ -14,9 +14,9 @@
     <Description>A .NET Core wrapper for the Zoopla.co.uk API, enabling retrieval of property listings, estimates, area information, and urls for associated graphs.</Description>
     <PackageProjectUrl>https://github.com/ianrufus/Zoopla.Net</PackageProjectUrl>
     <PackageTags>Zoopla, RightMove, Property, NetCore, NetStandard</PackageTags>
-    <PackageReleaseNotes>Disambiguation property added to base response</PackageReleaseNotes>
+    <PackageReleaseNotes>Added GetListingsByIds method to client</PackageReleaseNotes>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Zoopla.Net/ZooplaDotNetClient.cs
+++ b/src/Zoopla.Net/ZooplaDotNetClient.cs
@@ -17,6 +17,25 @@ namespace Zoopla.Net
         }
 
         /// <summary>
+        /// Gets listings of properties by IDs for sale, rent or either, depending on the supplied options.
+        /// </summary>
+        /// <param name="options">The byId, rental or sales listing options.</param>
+        /// <returns>A list of properties matching the given criteria.</returns>
+        public Task<PropertyListingsResponse> GetPropertyListingsByIds(ListingBaseOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrEmpty(options.ListingId))
+                throw new ArgumentNullException(nameof(options.ListingId), "The listing options object must have a listingId set");
+
+            string url = Endpoints.PROPERTY_LISTINGS + "?api_key=" + _accessToken;
+            
+            url += options.GetUrlParams();
+
+            return _httpClient.GetObject<PropertyListingsResponse>(url);
+        }
+
+        /// <summary>
         /// Gets listings of properties either for sale or rent, depending on the supplied options.
         /// </summary>
         /// <param name="locationParams">The standard location parameters.</param>


### PR DESCRIPTION
I need to get properties by ID without knowing if they are sale or rent properties. This is perfectly doable through the API so just allowing it through the client.

I've added a new client method `GetPropertyListingsByIds` because location options are ignored when specifying ID so I would like to leave the `StandardLocationParameters` out of the call. Listing filters are still relevant though so I'm allowing the full `ListingBaseOptions` through.

Sale or Rent can still be specified if this is known along with their specific parameters if needed using their Sale/Rent ListingOptions.