### PR TITLE
Added documentation output for NuGet package

### DIFF
--- a/src/Zoopla.Net/Zoopla.Net.csproj
+++ b/src/Zoopla.Net/Zoopla.Net.csproj
@@ -17,6 +17,7 @@
     <PackageReleaseNotes>Added GetListingsByIds method to client</PackageReleaseNotes>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Version>1.2.2</Version>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
this PR keeps all the stuff in the `<summary>` tags elements in the NuGet package, so consumers can still see the method/class/property descriptions and usages